### PR TITLE
Fix/clutter-free-heading

### DIFF
--- a/clutter-free-headings.css
+++ b/clutter-free-headings.css
@@ -15,7 +15,7 @@ div.HyperMD-header:not(.cm-active)>span.cm-header::before {
   margin-right: 0.75rem;
   overflow:visible;
   font-size: 0.75rem;
-  color: var(--text-muted);
+  color: var(--text-faint);
 }
 div.HyperMD-header-1:not(.cm-active)>span.cm-header-1::before {
   content: 'H1';

--- a/clutter-free-headings.css
+++ b/clutter-free-headings.css
@@ -1,46 +1,37 @@
-.markdown-preview-view h1, .cm-header-1 { font-size: 2.33rem; }
-.markdown-preview-view h2, .cm-header-2 { font-size: 1.83rem; }
-.markdown-preview-view h3, .cm-header-3 { font-size: 1.5rem; }
-.markdown-preview-view h4, .cm-header-4 { font-size: 1.33rem; }
-.markdown-preview-view h5, .cm-header-5 { font-size: 1.16rem; }
-.markdown-preview-view h6, .cm-header-6 { font-size: 1rem; }
+div.HyperMD-header>span.cm-formatting-header-1 { font-size: 1.123rem !important; }
+div.HyperMD-header>span.cm-formatting-header-2 { font-size: 0.746rem !important; }
+div.HyperMD-header>span.cm-formatting-header-3 { font-size: 0.54rem !important; }
+div.HyperMD-header>span.cm-formatting-header-4 { font-size: 0.39rem !important; }
+div.HyperMD-header>span.cm-formatting-header-5 { font-size: 0.3rem !important; }
+div.HyperMD-header>span.cm-formatting-header-6 { font-size: 0.24rem !important; }
 
-.cm-formatting-header-1 { font-size: 2rem; }
-.cm-formatting-header-2 { font-size: 1.16rem; }
-.cm-formatting-header-3 { font-size: 0.83rem; }
-.cm-formatting-header-4 { font-size: 0.64rem; }
-.cm-formatting-header-5 { font-size: 0.52rem; }
-.cm-formatting-header-6 { font-size: 0.44rem; }
+div.HyperMD-header.cm-active>span.cm-formatting-header { margin-right: 0.75rem; }
 
-div:not(.CodeMirror-activeline)>.CodeMirror-line span.cm-formatting-header {
-  color: transparent !important;
-  background:none;
-}
-
-div:not(.CodeMirror-activeline)>.CodeMirror-line span.cm-formatting-header::before {
+div.HyperMD-header:not(.cm-active)>span.cm-header::before {
   display: inline-block;
   white-space: nowrap;
   word-wrap: none;
-  width:0;
+  width: auto;
+  margin-right: 0.75rem;
   overflow:visible;
   font-size: 0.75rem;
   color: var(--text-muted);
 }
-div:not(.CodeMirror-activeline)>.CodeMirror-line span.cm-formatting-header-1::before {
+div.HyperMD-header-1:not(.cm-active)>span.cm-header-1::before {
   content: 'H1';
 }
-div:not(.CodeMirror-activeline)>.CodeMirror-line span.cm-formatting-header-2::before {
+div.HyperMD-header-2:not(.cm-active)>span.cm-header-2::before {
   content: 'H2';
 }
-div:not(.CodeMirror-activeline)>.CodeMirror-line span.cm-formatting-header-3::before {
+div.HyperMD-header-3:not(.cm-active)>span.cm-header-3::before {
   content: 'H3';
 }
-div:not(.CodeMirror-activeline)>.CodeMirror-line span.cm-formatting-header-4::before {
+div.HyperMD-header-4:not(.cm-active)>span.cm-header-4::before {
   content: 'H4';
 }
-div:not(.CodeMirror-activeline)>.CodeMirror-line span.cm-formatting-header-5::before {
+div.HyperMD-header-5:not(.cm-active)>span.cm-header-5::before {
   content: 'H5';
 }
-div:not(.CodeMirror-activeline)>.CodeMirror-line span.cm-formatting-header-6::before {
+div.HyperMD-header-6:not(.cm-active)>span.cm-header-6::before {
   content: 'H6';
 }


### PR DESCRIPTION
* Fix: show signs like the screenshot shows
  ![](https://github.com/deathau/obsidian-snippets/blob/1624b477ab318f81e8989011cc069d67930489f6/images/clutter-free-headings.gif)
* Feat align color of pound sign and artificial sign

This is working on Obsidian v1.6.7 with default theme.

I tried #13 but maybe there's something changed in the middle so it's not really working now